### PR TITLE
Remove tsx files to prevent import issue

### DIFF
--- a/scripts/utils/postprocess-files.cjs
+++ b/scripts/utils/postprocess-files.cjs
@@ -5,7 +5,7 @@ const path = require('path');
 const distDir =
   process.env['DIST_PATH'] ?
     path.resolve(process.env['DIST_PATH'])
-  : path.resolve(__dirname, '..', '..', 'dist');
+    : path.resolve(__dirname, '..', '..', 'dist');
 
 async function* walk(dir) {
   for await (const d of await fs.promises.opendir(dir)) {
@@ -16,6 +16,13 @@ async function* walk(dir) {
 }
 
 async function postprocess() {
+  // Remove source TypeScript files to avoid module resolution conflicts
+  const srcDir = path.join(distDir, 'src');
+  if (fs.existsSync(srcDir)) {
+    console.error('Removing source files from dist/src to prevent module resolution conflicts...');
+    await fs.promises.rm(srcDir, { recursive: true, force: true });
+  }
+
   for await (const file of walk(distDir)) {
     if (!/(\.d)?[cm]?ts$/.test(file)) continue;
 
@@ -79,7 +86,7 @@ async function postprocess() {
     'dist/package.json',
     JSON.stringify(
       Object.assign(
-        /** @type {Record<String, unknown>} */ (
+        /** @type {Record<String, unknown>} */(
           JSON.parse(await fs.promises.readFile('dist/package.json', 'utf-8'))
         ),
         {


### PR DESCRIPTION
### TL;DR

Remove TypeScript source files from the distribution to prevent module resolution conflicts.

### What changed?

Added functionality to the post-processing script that removes the `dist/src` directory containing TypeScript source files. This prevents potential module resolution conflicts that could occur when both compiled JavaScript and original TypeScript files are present in the distribution.

### How to test?

1. Run the build process
2. Verify that the `dist/src` directory is removed from the output
3. Confirm that module imports work correctly without resolution conflicts

### Why make this change?

When TypeScript source files are included in the distribution alongside compiled JavaScript files, it can cause module resolution conflicts. This is particularly problematic when tools attempt to resolve imports and find both the source and compiled versions of the same module. Removing the source files ensures that only the compiled JavaScript files are used, providing a cleaner and more reliable distribution package.