### PR TITLE
seperate file stuff so it doesn't cause client-side errors

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,2 @@
+// File for Node.js-specific utilities that shouldn't be bundled with client-side code
+export { collectFiles, applyChanges, type FileData } from './lib/helpers';

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,5 +21,4 @@ export {
   UnprocessableEntityError,
 } from './core/error';
 
-export { collectFiles, applyChanges, type FileData } from './lib/helpers';
 export { BundleRenderer, type BundleFile } from './lib/bundle-renderer';


### PR DESCRIPTION
### TL;DR

Move Node.js-specific utilities to a separate file to optimize client-side bundling.

### What changed?

- Created a new file `src/helpers.ts` that re-exports Node.js-specific utilities (`collectFiles`, `applyChanges`, and `FileData` type)
- Removed these exports from `src/index.ts`
- Added a comment clarifying that these utilities are Node.js-specific and shouldn't be bundled with client-side code

### How to test?

1. Import the utilities from both the new location and the old location:
   ```typescript
   import { collectFiles, applyChanges } from './helpers';
   ```
2. Verify that the functionality works as expected
3. Check that client-side bundles no longer include these utilities when importing from the main index

### Why make this change?

This change improves bundle size optimization for client-side applications by separating Node.js-specific utilities from the main exports. This allows bundlers to exclude these utilities when they're not needed in browser environments, resulting in smaller bundle sizes and better performance.