### PR TITLE
export helper functions BEN-2351

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,6 @@ export {
 } from './core/error';
 
 export { BundleRenderer, type BundleFile } from './lib/bundle-renderer';
+
+// Helper utilities
+export { collectFiles, applyChanges, type FileData } from './helpers';


### PR DESCRIPTION
### TL;DR

Export helper utilities from the main index file.

### What changed?

Added exports for `collectFiles`, `applyChanges`, and the `FileData` type from the `./helpers` module to make these utilities publicly available through the package's main entry point.

### How to test?

1. Import the newly exported utilities in your code:
   ```typescript
   import { collectFiles, applyChanges, FileData } from 'your-package-name';
   ```
2. Verify that the imported utilities work as expected in your application.

### Why make this change?

These helper utilities were previously only available internally or through direct imports from the helpers module. Exposing them through the main index file improves developer experience by making commonly used utilities more accessible and discoverable.