### PR TITLE
Make all the functions avalible on benchify import

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,16 +63,6 @@
         "default": "./dist/index.js"
       }
     },
-    "./helpers": {
-      "import": {
-        "types": "./dist/helpers.d.mts",
-        "default": "./dist/helpers.mjs"
-      },
-      "require": {
-        "types": "./dist/helpers.d.ts",
-        "default": "./dist/helpers.js"
-      }
-    },
     "./*.mjs": {
       "default": "./dist/*.mjs"
     },

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,0 @@
-// File for Node.js-specific utilities that shouldn't be bundled with client-side code
-// Import from 'benchify/helpers' to use these utilities
-export { collectFiles, applyChanges, type FileData } from './lib/helpers';

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -23,4 +23,4 @@ export {
 export { BundleRenderer, type BundleFile } from './lib/bundle-renderer';
 
 // Node.js-only helper utilities (uses fs module)
-export { collectFiles, applyChanges, type FileData } from './helpers';
+export { collectFiles, applyChanges, type FileData } from './lib/helpers';

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,4 @@ export {
 } from './core/error';
 
 export { BundleRenderer, type BundleFile } from './lib/bundle-renderer';
+export { collectFiles, applyChanges, type FileData } from './lib/helpers';

--- a/src/lib/bundle-renderer.tsx
+++ b/src/lib/bundle-renderer.tsx
@@ -84,7 +84,7 @@ export function BundleRenderer({
       const mime = f.contentType ?? guessType(p);
       typeByPath.set(p, mime);
       const data = toUint8(f.contents);
-      const url = URL.createObjectURL(new Blob([data], { type: mime }));
+      const url = URL.createObjectURL(new Blob([new Uint8Array(data)], { type: mime }));
       objectURLs.push(url);
       rawBlobUrlByPath.set(p, url);
     }
@@ -255,15 +255,15 @@ function cleanPath(p: string) {
   return p.replace(/^\/+/, '');
 }
 
-function toUint8(x: string | Uint8Array | ArrayBuffer) {
+function toUint8(x: string | Uint8Array | ArrayBuffer): Uint8Array {
   if (typeof x === 'string') return new TextEncoder().encode(x);
   if (x instanceof Uint8Array) return x;
-  return new Uint8Array(x);
+  return new Uint8Array(x as ArrayBuffer);
 }
 
 function getText(x: string | Uint8Array | ArrayBuffer) {
   if (typeof x === 'string') return x;
-  const u8 = x instanceof Uint8Array ? x : new Uint8Array(x);
+  const u8 = x instanceof Uint8Array ? x : new Uint8Array(x as ArrayBuffer);
   return new TextDecoder().decode(u8);
 }
 


### PR DESCRIPTION
### TL;DR

Removed the separate helpers export path and integrated helper functions directly into the main package exports, with browser-safe conditional imports.

### What changed?

- Removed the separate `./helpers` export path from `package.json`
- Deleted the standalone `src/helpers.ts` file
- Modified `src/lib/helpers.ts` to conditionally load Node.js modules (fs, path, process) to avoid errors in browser environments
- Added helpful error messages when Node.js-specific functions are called in browser contexts
- Exported helper functions directly from the main entry points
- Fixed type issues in the `BundleRenderer` component's handling of binary data
- Updated the binary benchmark file

### How to test?

1. Import helper functions directly from the main package:
   ```js
   import { collectFiles, applyChanges } from 'benchify';
   ```

2. Verify that helpful error messages appear when trying to use Node.js-specific functions in a browser environment

3. Test the `BundleRenderer` component with binary files to ensure proper handling

### Why make this change?

This change simplifies the package's export structure by removing the separate helpers path, while making the codebase more robust in browser environments. By conditionally loading Node.js modules and providing clear error messages, the package now handles cross-environment usage more gracefully. The updated type handling in `BundleRenderer` also improves the reliability when working with binary data.