### PR TITLE
another attempt to fix import issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,26 @@
         "default": "./dist/index.js"
       }
     },
+    "./helpers": {
+      "import": {
+        "types": "./dist/helpers.d.mts",
+        "default": "./dist/helpers.mjs"
+      },
+      "require": {
+        "types": "./dist/helpers.d.ts",
+        "default": "./dist/helpers.js"
+      }
+    },
+    "./react": {
+      "import": {
+        "types": "./dist/lib/bundle-renderer.d.mts",
+        "default": "./dist/lib/bundle-renderer.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/bundle-renderer.d.ts",
+        "default": "./dist/lib/bundle-renderer.js"
+      }
+    },
     "./*.mjs": {
       "default": "./dist/*.mjs"
     },

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,2 @@
+// File for Node.js-specific utilities that shouldn't be bundled with client-side code
+export { collectFiles, applyChanges, type FileData } from './lib/helpers';

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,3 @@ export {
   PermissionDeniedError,
   UnprocessableEntityError,
 } from './core/error';
-
-export { BundleRenderer, type BundleFile } from './lib/bundle-renderer';
-export { collectFiles, applyChanges, type FileData } from './lib/helpers';

--- a/src/lib/bundle-renderer.tsx
+++ b/src/lib/bundle-renderer.tsx
@@ -1,22 +1,4 @@
-// Conditionally load React to avoid errors when React is not installed
-let React: any;
-let useEffect: typeof import('react').useEffect;
-let useMemo: typeof import('react').useMemo;
-let useRef: typeof import('react').useRef;
-
-try {
-  const ReactModule = require('react');
-  React = ReactModule.default || ReactModule;
-  useEffect = ReactModule.useEffect;
-  useMemo = ReactModule.useMemo;
-  useRef = ReactModule.useRef;
-} catch (err) {
-  // React not available - will throw helpful error when component is used
-  React = null;
-  useEffect = null as any;
-  useMemo = null as any;
-  useRef = null as any;
-}
+import React, { useEffect, useMemo, useRef } from 'react';
 
 export type BundleFile = {
   path: string; // e.g., "index.html", "assets/chunk-XYZ.js"
@@ -46,15 +28,6 @@ export function BundleRenderer({
   sandbox = 'allow-scripts allow-same-origin',
   title = 'vite-bundle-iframe',
 }: Props) {
-  if (!React) {
-    throw new Error(
-      'BundleRenderer requires React to be installed. Please install React:\n' +
-        '  npm install react\n' +
-        '  # or\n' +
-        '  yarn add react',
-    );
-  }
-
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   // Normalize and index files by clean path

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,29 +1,5 @@
-// Conditionally load Node.js modules to avoid errors in browser environments
-let fs: any;
-let path: any;
-let process: any;
-
-try {
-  fs = require('fs');
-  path = require('path');
-  process = require('process');
-} catch (err) {
-  // Node.js modules not available - will throw helpful error when functions are used
-  fs = null;
-  path = null;
-  process = null;
-}
-
-function ensureNodeEnvironment(functionName: string) {
-  if (!fs || !path || !process) {
-    throw new Error(
-      `${functionName} requires Node.js environment and is not available in browsers.\n` +
-        'This function uses Node.js filesystem APIs (fs, path) which are not available in browser environments.\n' +
-        'Please use this function only in Node.js server-side code.',
-    );
-  }
-}
-
+import fs from 'fs';
+import path from 'path';
 import { minimatch } from 'minimatch';
 
 export interface FileData {
@@ -83,14 +59,11 @@ function walkDirectory(dir: string, basePath: string, patterns: string[], ignore
 }
 
 export async function collectFiles({
-  basePath,
+  basePath = process.cwd(),
   patterns = DEFAULT_PATTERNS,
   ignore = DEFAULT_IGNORE,
 }: { basePath?: string; patterns?: string[]; ignore?: string[] } = {}): Promise<FileData[]> {
-  ensureNodeEnvironment('collectFiles');
-
-  const defaultBasePath = basePath || process.cwd();
-  const resolvedBasePath = path.resolve(defaultBasePath);
+  const resolvedBasePath = path.resolve(basePath);
   const filePaths = walkDirectory(resolvedBasePath, resolvedBasePath, patterns, ignore);
 
   const files: FileData[] = [];
@@ -113,13 +86,16 @@ export async function collectFiles({
   return files;
 }
 
-export function applyChanges({ files, basePath }: { files: FileData[]; basePath?: string }): void {
-  ensureNodeEnvironment('applyChanges');
-
-  const defaultBasePath = basePath || process.cwd();
+export function applyChanges({
+  files,
+  basePath = process.cwd(),
+}: {
+  files: FileData[];
+  basePath?: string;
+}): void {
   for (const file of files) {
     try {
-      const fullPath = path.resolve(defaultBasePath, file.path);
+      const fullPath = path.resolve(basePath, file.path);
       const dirPath = path.dirname(fullPath);
 
       fs.mkdirSync(dirPath, { recursive: true });


### PR DESCRIPTION
### TL;DR

Restructured package exports to improve module organization and reduce browser bundle size.

### What changed?

- Added new entry points in `package.json`:
  - `./helpers` for Node.js-specific utilities
  - `./react` for React components
- Created a new `helpers.ts` file to export Node.js-specific utilities
- Removed Node.js and React imports from the main bundle
- Modified `bundle-renderer.tsx` to directly import React instead of conditionally loading it
- Updated `helpers.ts` to use direct imports instead of conditional requires
- Simplified parameter handling with default values in helper functions

### How to test?

1. Verify the package builds correctly with `npm run build`
2. Import from the new entry points:
   ```js
   // For React components
   import { BundleRenderer } from 'your-package/react';
   
   // For Node.js helpers
   import { collectFiles, applyChanges } from 'your-package/helpers';
   ```
3. Confirm the main bundle works in browser environments without errors
4. Check that the Node.js helpers work correctly in server environments

### Why make this change?

This change improves the package architecture by:
1. Reducing the main bundle size by moving environment-specific code to dedicated entry points
2. Eliminating conditional imports that add complexity and bundle size
3. Providing a cleaner API for consumers with explicit entry points for different environments
4. Preventing accidental usage of Node.js utilities in browser environments